### PR TITLE
Changing note value to "text" type because hsqldb 2.3.0 tries to store i...

### DIFF
--- a/biosql/src/main/java/org/biojavax/bio/db/biosql/hsqldb/Feature.hbm.xml
+++ b/biosql/src/main/java/org/biojavax/bio/db/biosql/hsqldb/Feature.hbm.xml
@@ -24,7 +24,7 @@
             <key column="seqfeature_id" not-null="true"/>
             <composite-element class="org.biojavax.SimpleNote" node="note">
                 <many-to-one name="term" class="Term" column="term_id" not-null="true" cascade="persist,merge,save-update" node="@termId" embed-xml="false"/>
-                <property name="value"/>
+                <property name="value", type="text"/>
                 <property name="rank" node="@rank"/>
             </composite-element>
         </set>  


### PR DESCRIPTION
I was storing some data from NCBI that was parsed by RichSequence.IOTools.readGenbankDNA() and got the following exception:

Caused by: org.hibernate.exception.DataException: Could not execute JDBC batch update
Caused by: java.sql.BatchUpdateException: data exception: string data, right truncation;  table: SEQFEATURE_QUALIFIER_VALUE column: VALUE

because Hibernate auto-create will map the String value to var-char by default. By setting the hibernate type as text, we avoid the bug by giving the database a large enough store to hold the whole "value" string.
