### PR TITLE
make SubstitutionMatrix serializable

### DIFF
--- a/alignment/src/main/java/org/biojava/bio/alignment/SubstitutionMatrix.java
+++ b/alignment/src/main/java/org/biojava/bio/alignment/SubstitutionMatrix.java
@@ -30,6 +30,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.io.Serializable;
 import java.io.StringReader;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -63,7 +64,7 @@ import org.biojava.bio.symbol.Symbol;
  * 
  * @author Andreas Dr&auml;ger <andreas.draeger@uni-tuebingen.de>
  */
-public class SubstitutionMatrix {
+public class SubstitutionMatrix implements Serializable {
 	
 	/**
 	 * 

--- a/alignment/src/test/java/org/biojava/bio/alignment/SubstitutionMatrixTest.java
+++ b/alignment/src/test/java/org/biojava/bio/alignment/SubstitutionMatrixTest.java
@@ -24,9 +24,14 @@
 package org.biojava.bio.alignment;
 
 import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
 import java.io.StringReader;
 
 import junit.framework.TestCase;
@@ -483,5 +488,22 @@ public class SubstitutionMatrixTest extends TestCase {
         catch (NullPointerException e) {
             // expected
         }
+    }
+
+    public void testSerializable() {
+        assertTrue(SubstitutionMatrix.getNuc4_4() instanceof Serializable);
+    }
+
+    public void testSerialization() throws Exception {
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        ObjectOutputStream out = new ObjectOutputStream(buffer);
+        out.writeObject(SubstitutionMatrix.getNuc4_4());
+        out.close();
+
+        ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(buffer.toByteArray()));
+        Object dest = in.readObject();
+        in.close();
+
+        assertTrue(dest instanceof SubstitutionMatrix);
     }
 }


### PR DESCRIPTION
This is necessary for running biojava SW across a Spark cluster (http://spark.apache.org/).
