### PR TITLE
GenbankFormat changes to allow reading of Ensembl Genbank files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .project
 .classpath
 .settings
+.idea/
 target

--- a/core/src/main/java/org/biojavax/bio/seq/io/GenbankFormat.java
+++ b/core/src/main/java/org/biojavax/bio/seq/io/GenbankFormat.java
@@ -443,6 +443,7 @@ public class GenbankFormat extends RichSequenceFormat.HeaderlessFormat {
 	                            if (val.endsWith("\"")) val = val.substring(1,val.length()-1); // strip quotes
 	                            // parameter on old feature
 	                            if (key.equals("db_xref")) {
+                                    val = val.replaceAll("\\s+","");
 	                                Matcher m = dbxp.matcher(val);
 	                                if (m.matches()) {
 	                                    String dbname = m.group(1);
@@ -593,6 +594,9 @@ public class GenbankFormat extends RichSequenceFormat.HeaderlessFormat {
                     br.reset();
                     done = true;
                 } else {
+                    if (getElideSymbols() && firstSecKey.equals(START_SEQUENCE_TAG) && !line.startsWith(END_SEQUENCE_TAG)) {
+                        continue;
+                    }
                     Matcher m = sectp.matcher(line);
                     if (m.matches()) {
                         // new key

--- a/core/src/test/java/org/biojavax/bio/seq/io/GenbankFormatTest.java
+++ b/core/src/test/java/org/biojavax/bio/seq/io/GenbankFormatTest.java
@@ -8,6 +8,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.StringReader;
 import java.util.Iterator;
+import java.util.zip.GZIPInputStream;
 
 import junit.framework.TestCase;
 
@@ -102,7 +103,15 @@ public class GenbankFormatTest extends TestCase {
 
     public void testEnsemblGenbankFile() {
         gbFormat.setElideSymbols(true);
-        RichSequence sequence = readDNAFile("/Homo_sapiens.GRCh38.77.chromosome.1.dat");
+        GZIPInputStream gzInStream = null;
+        try {
+            InputStream inStream = this.getClass().getResourceAsStream("/Homo_sapiens.GRCh38.77.chromosome.1.dat.gz");
+            gzInStream = new GZIPInputStream(inStream);
+        } catch (IOException e) {
+            e.printStackTrace();
+            fail("Unable to create input stream");
+        }
+        RichSequence sequence = readDNAStream(gzInStream);
         assertNotNull(sequence);
     }
 
@@ -162,6 +171,10 @@ public class GenbankFormatTest extends TestCase {
      */
     private RichSequence readDNAFile(String filename) {
         InputStream inStream = this.getClass().getResourceAsStream(filename);
+        return readDNAStream(inStream);
+    }
+
+    private RichSequence readDNAStream(InputStream inStream) {
         BufferedReader br = new BufferedReader(new InputStreamReader(inStream));
         SymbolTokenization tokenization = RichSequence.IOTools.getDNAParser();
         Namespace namespace = RichObjectFactory.getDefaultNamespace();

--- a/core/src/test/java/org/biojavax/bio/seq/io/GenbankFormatTest.java
+++ b/core/src/test/java/org/biojavax/bio/seq/io/GenbankFormatTest.java
@@ -100,7 +100,6 @@ public class GenbankFormatTest extends TestCase {
         assertEquals("NoAccess", sequence.getAccession());
     }
 
-    @Ignore("requires -Xmx1g to process size of file")
     public void testEnsemblGenbankFile() {
         gbFormat.setElideSymbols(true);
         RichSequence sequence = readDNAFile("/Homo_sapiens.GRCh38.77.chromosome.1.dat");

--- a/core/src/test/java/org/biojavax/bio/seq/io/GenbankFormatTest.java
+++ b/core/src/test/java/org/biojavax/bio/seq/io/GenbankFormatTest.java
@@ -19,6 +19,7 @@ import org.biojavax.RichObjectFactory;
 import org.biojavax.bio.seq.RichSequence;
 import org.biojavax.bio.seq.io.GenbankFormat.Terms;
 import org.biojavax.bio.taxa.NCBITaxon;
+import org.junit.Ignore;
 
 /**
  * Tests for GenbankFormat. Ain't parsing fun?
@@ -97,6 +98,13 @@ public class GenbankFormatTest extends TestCase {
     	RichSequence sequence = readDNAFile("/NoAccession.gb");
         assertNotNull(sequence);
         assertEquals("NoAccess", sequence.getAccession());
+    }
+
+    @Ignore("requires -Xmx1g to process size of file")
+    public void testEnsemblGenbankFile() {
+        gbFormat.setElideSymbols(true);
+        RichSequence sequence = readDNAFile("/Homo_sapiens.GRCh38.77.chromosome.1.dat");
+        assertNotNull(sequence);
     }
 
     public void testCanReadWhatIsWritten() {

--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,9 @@
 	<plugin>
 	  <artifactId>maven-surefire-plugin</artifactId>
 	  <version>2.17</version>
+          <configuration>
+            <argLine>-Xmx4g</argLine>
+          </configuration>
 	</plugin>
 	<plugin>
 	  <groupId>org.jvnet.jaxb2.maven2</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
 	  <artifactId>maven-surefire-plugin</artifactId>
 	  <version>2.17</version>
           <configuration>
-            <argLine>-Xmx4g</argLine>
+            <argLine>-Xmx1g</argLine>
           </configuration>
 	</plugin>
 	<plugin>


### PR DESCRIPTION
The existing GenbankFormat has not been able to read Ensembl Genbank files for a while. Part of the problem was db_xrefs that crossed over to the next line.  The other issue was that it was still reading and processing the symbol list even though elideSymbols was set.  These changes will allow for one to be able to read these files but they also require a bit of memory so I'm not sure you want to take the test cases.