### PR TITLE
adding Fastq.convertTo(FastqVariant) and supporting methods

### DIFF
--- a/sequencing/src/main/java/org/biojava/bio/program/fastq/AbstractFastqWriter.java
+++ b/sequencing/src/main/java/org/biojava/bio/program/fastq/AbstractFastqWriter.java
@@ -40,12 +40,14 @@ abstract class AbstractFastqWriter
 {
 
     /**
-     * Validate the specified FASTQ formatted sequence for writing.
+     * Convert the specified FASTQ formatted sequence if necessary.
      *
-     * @param fastq FASTQ formatted sequence to validate, will not be null
-     * @throws IOException if the specified FASTQ formatted sequence is not valid for writing
+     * @since 1.9.3
+     * @param fastq FASTQ formatted sequence to convert, must not be null
+     * @return the specified FASTQ formatted sequence or a new FASTA formatted
+     *    sequence if conversion is necessary
      */
-    protected abstract void validate(final Fastq fastq) throws IOException;
+    protected abstract Fastq convert(final Fastq fastq);
 
     /** {@inheritDoc} */
     public final <T extends Appendable> T append(final T appendable, final Fastq... fastq) throws IOException
@@ -66,16 +68,15 @@ abstract class AbstractFastqWriter
         }
         for (Fastq f : fastq)
         {
-            validate(f);
             if (f != null)
             {
+                Fastq converted = convert(f);
                 appendable.append("@");
-                appendable.append(f.getDescription());
+                appendable.append(converted.getDescription());
                 appendable.append("\n");
-                appendable.append(f.getSequence());
-                appendable.append("\n");
-                appendable.append("+\n");
-                appendable.append(f.getQuality());
+                appendable.append(converted.getSequence());
+                appendable.append("\n+\n");
+                appendable.append(converted.getQuality());
                 appendable.append("\n");
             }
         }

--- a/sequencing/src/main/java/org/biojava/bio/program/fastq/Fastq.java
+++ b/sequencing/src/main/java/org/biojava/bio/program/fastq/Fastq.java
@@ -122,6 +122,20 @@ public final class Fastq
     }
 
     /**
+     * Create and return a new FASTQ formatted sequence from this converted to the
+     * specified FASTQ sequence format variant.
+     *
+     * @since 1.9.3
+     * @param variant FASTQ sequence format variant, must not be null
+     * @return a new FASTQ formatted sequence from this converted to the
+     *    specified FASTQ sequence format variant
+     */
+    public Fastq convertTo(final FastqVariant variant)
+    {
+        return FastqTools.convert(this, variant);
+    }
+
+    /**
      * Create and return a new FastqBuilder.
      * The FastqBuilder will not be null.
      *

--- a/sequencing/src/main/java/org/biojava/bio/program/fastq/FastqTools.java
+++ b/sequencing/src/main/java/org/biojava/bio/program/fastq/FastqTools.java
@@ -273,4 +273,65 @@ public final class FastqTools
         }
         return errorProbabilities;
     }
+
+    /**
+     * Convert the specified FASTQ formatted sequence to the
+     * specified FASTQ sequence format variant.
+     *
+     * @since 1.9.3
+     * @param fastq FASTQ formatted sequence, must not be null
+     * @param variant FASTQ sequence format variant, must not be null
+     * @return the specified FASTQ formatted sequence converted to the
+     *    specified FASTQ sequence format variant
+     */
+    public static Fastq convert(final Fastq fastq, final FastqVariant variant)
+    {
+        if (fastq == null)
+        {
+            throw new IllegalArgumentException("fastq must not be null");
+        }
+        if (variant == null)
+        {
+            throw new IllegalArgumentException("variant must not be null");
+        }
+        if (fastq.getVariant().equals(variant))
+        {
+            return fastq;
+        }
+        return new Fastq(fastq.getDescription(), fastq.getSequence(), convertQualities(fastq, variant), variant);
+    }
+
+    /**
+     * Convert the qualities in the specified FASTQ formatted sequence to the
+     * specified FASTQ sequence format variant.
+     *
+     * @since 1.9.3
+     * @param fastq FASTQ formatted sequence, must not be null
+     * @param variant FASTQ sequence format variant, must not be null
+     * @return the qualities in the specified FASTQ formatted sequence converted to the
+     *    specified FASTQ sequence format variant
+     */
+    static String convertQualities(final Fastq fastq, final FastqVariant variant)
+    {
+        if (fastq == null)
+        {
+            throw new IllegalArgumentException("fastq must not be null");
+        }
+        if (variant == null)
+        {
+            throw new IllegalArgumentException("variant must not be null");
+        }
+        if (fastq.getVariant().equals(variant))
+        {
+            return fastq.getQuality();
+        }
+        int size = fastq.getQuality().length();
+        double[] errorProbabilities = errorProbabilities(fastq, new double[size]);
+        StringBuilder sb = new StringBuilder(size);
+        for (int i = 0; i < size; i++)
+        {
+            sb.append(variant.quality(variant.qualityScore(errorProbabilities[i])));
+        }
+        return sb.toString();
+    }
 }

--- a/sequencing/src/main/java/org/biojava/bio/program/fastq/FastqVariant.java
+++ b/sequencing/src/main/java/org/biojava/bio/program/fastq/FastqVariant.java
@@ -52,6 +52,14 @@ public enum FastqVariant
         }
 
         @Override
+        public int qualityScore(final double errorProbability)
+        {
+            // eq. 2
+            int phredQ = constrain(-10.0d * Math.log10(errorProbability));
+            return phredQ;
+        }
+
+        @Override
         public char quality(final int qualityScore)
         {
             if (qualityScore < minimumQualityScore())
@@ -94,6 +102,17 @@ public enum FastqVariant
         }
 
         @Override
+        public int qualityScore(final double errorProbability)
+        {
+            // eq. 2
+            double phredQ = -10.0d * Math.log10(errorProbability);
+            // eq. 4
+            int solexaQ = constrain(10.0d * Math.log10(Math.pow(10.0d, (phredQ/10.0d)) - 1.0d));
+
+            return solexaQ;
+        }
+
+        @Override
         public char quality(final int qualityScore)
         {
             if (qualityScore < minimumQualityScore())
@@ -111,7 +130,7 @@ public enum FastqVariant
         public double errorProbability(final int qualityScore)
         {
             double q = Math.pow(10.0d, ((double) qualityScore) / -10.0d);
-            return q / (1 + q);
+            return q / (1.0d + q);
         }
     },
 
@@ -134,6 +153,14 @@ public enum FastqVariant
         public int qualityScore(final char c)
         {
             return ((int) c) - 64;
+        }
+
+        @Override
+        public int qualityScore(final double errorProbability)
+        {
+            // eq. 2
+            int phredQ = constrain(-10.0d * Math.log10(errorProbability));
+            return phredQ;
         }
 
         @Override
@@ -256,6 +283,15 @@ public enum FastqVariant
     public abstract int qualityScore(char c);
 
     /**
+     * Convert the specified error probability to a quality score.
+     *
+     * @since 1.9.3
+     * @param errorProbability error probability
+     * @return the specified error probability converted to a quality score
+     */
+    public abstract int qualityScore(double errorProbability);
+
+    /**
      * Convert the specified quality score to a quality in ASCII format.
      *
      * @since 1.8.3
@@ -296,6 +332,21 @@ public enum FastqVariant
         return name().toLowerCase().replace('_', '-');
     }
 
+
+    /**
+     * Constrain the specified quality score in double precision to the minimum and maximum quality
+     * scores in int precision.
+     *
+     * @since 1.9.3
+     * @param qualityScore quality score in double precision
+     * @return the specified quality score in double precision constrained to the minimum and maximum quality
+     *    scores in int precision
+     */
+    protected int constrain(final double qualityScore)
+    {
+        // ick.
+        return Math.min(maximumQualityScore(), Math.max(minimumQualityScore(), Math.round((float) qualityScore)));
+    }
 
     /**
      * Return the FASTQ sequence format variant with the specified name, if any.  The name may

--- a/sequencing/src/main/java/org/biojava/bio/program/fastq/IlluminaFastqWriter.java
+++ b/sequencing/src/main/java/org/biojava/bio/program/fastq/IlluminaFastqWriter.java
@@ -31,17 +31,9 @@ public final class IlluminaFastqWriter
     extends AbstractFastqWriter
 {
 
-    /** {@inheritDoc} */
-    protected void validate(final Fastq fastq) throws IOException
+    @Override
+    protected Fastq convert(final Fastq fastq)
     {
-        if (fastq == null)
-        {
-            return;
-        }
-        if (!fastq.getVariant().isIllumina())
-        {
-            throw new IOException("sequence " + fastq.getDescription()
-                                  + " not fastq-illumina format, was " + fastq.getVariant().lowercaseName());
-        }
+        return fastq.convertTo(FastqVariant.FASTQ_ILLUMINA);
     }
 }

--- a/sequencing/src/main/java/org/biojava/bio/program/fastq/SangerFastqWriter.java
+++ b/sequencing/src/main/java/org/biojava/bio/program/fastq/SangerFastqWriter.java
@@ -31,17 +31,9 @@ public final class SangerFastqWriter
     extends AbstractFastqWriter
 {
 
-    /** {@inheritDoc} */
-    protected void validate(final Fastq fastq) throws IOException
+    @Override
+    protected Fastq convert(final Fastq fastq)
     {
-        if (fastq == null)
-        {
-            return;
-        }
-        if (!fastq.getVariant().isSanger())
-        {
-            throw new IOException("sequence " + fastq.getDescription()
-                                  + " not fastq-sanger format, was " + fastq.getVariant().lowercaseName());
-        }
+        return fastq.convertTo(FastqVariant.FASTQ_SANGER);
     }
 }

--- a/sequencing/src/main/java/org/biojava/bio/program/fastq/SolexaFastqWriter.java
+++ b/sequencing/src/main/java/org/biojava/bio/program/fastq/SolexaFastqWriter.java
@@ -31,17 +31,9 @@ public final class SolexaFastqWriter
     extends AbstractFastqWriter
 {
 
-    /** {@inheritDoc} */
-    protected void validate(final Fastq fastq) throws IOException
+    @Override
+    protected Fastq convert(final Fastq fastq)
     {
-        if (fastq == null)
-        {
-            return;
-        }
-        if (!fastq.getVariant().isSolexa())
-        {
-            throw new IOException("sequence " + fastq.getDescription()
-                                  + " not fastq-solexa format, was " + fastq.getVariant().lowercaseName());
-        }
+        return fastq.convertTo(FastqVariant.FASTQ_SOLEXA);
     }
 }

--- a/sequencing/src/test/java/org/biojava/bio/program/fastq/ConvertTest.java
+++ b/sequencing/src/test/java/org/biojava/bio/program/fastq/ConvertTest.java
@@ -1,0 +1,146 @@
+/*
+ *                    BioJava development code
+ *
+ * This code may be freely distributed and modified under the
+ * terms of the GNU Lesser General Public Licence.  This should
+ * be distributed with the code.  If you do not have a copy,
+ * see:
+ *
+ *      http://www.gnu.org/copyleft/lesser.html
+ *
+ * Copyright for this code is held jointly by the individual
+ * authors.  These should be listed in @author doc comments.
+ *
+ * For more information on the BioJava project and its aims,
+ * or to join the biojava-l mailing list, visit the home page
+ * at:
+ *
+ *      http://www.biojava.org/
+ *
+ */
+package org.biojava.bio.program.fastq;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+
+import java.util.List;
+import java.util.Map;
+
+import junit.framework.TestCase;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
+/**
+ * Round trip conversion functional tests.
+ */
+public final class ConvertTest
+    extends TestCase
+{
+
+    public void testConvert() throws Exception
+    {
+        Map<FastqVariant, FastqReader> readers = Maps.newHashMap();
+        readers.put(FastqVariant.FASTQ_SANGER, new SangerFastqReader());
+        readers.put(FastqVariant.FASTQ_SOLEXA, new SolexaFastqReader());
+        readers.put(FastqVariant.FASTQ_ILLUMINA, new IlluminaFastqReader());
+
+        Map<FastqVariant, FastqWriter> writers = Maps.newHashMap();
+        writers.put(FastqVariant.FASTQ_SANGER, new SangerFastqWriter());
+        writers.put(FastqVariant.FASTQ_SOLEXA, new SolexaFastqWriter());
+        writers.put(FastqVariant.FASTQ_ILLUMINA, new IlluminaFastqWriter());
+
+        Map<FastqVariant, String> inputFileNames = Maps.newHashMap();
+        inputFileNames.put(FastqVariant.FASTQ_SANGER, "sanger_full_range_as_sanger.fastq");
+        inputFileNames.put(FastqVariant.FASTQ_SOLEXA, "solexa_full_range_as_solexa.fastq");
+        inputFileNames.put(FastqVariant.FASTQ_ILLUMINA, "illumina_full_range_as_illumina.fastq");
+
+        Map<FastqVariantPair, String> expectedFileNames = Maps.newHashMap();
+        expectedFileNames.put(new FastqVariantPair(FastqVariant.FASTQ_SANGER, FastqVariant.FASTQ_SANGER), "sanger_full_range_as_sanger.fastq");
+        expectedFileNames.put(new FastqVariantPair(FastqVariant.FASTQ_SANGER, FastqVariant.FASTQ_SOLEXA), "sanger_full_range_as_solexa.fastq");
+        expectedFileNames.put(new FastqVariantPair(FastqVariant.FASTQ_SANGER, FastqVariant.FASTQ_ILLUMINA), "sanger_full_range_as_illumina.fastq");
+        expectedFileNames.put(new FastqVariantPair(FastqVariant.FASTQ_SOLEXA, FastqVariant.FASTQ_SANGER), "solexa_full_range_as_sanger.fastq");
+        expectedFileNames.put(new FastqVariantPair(FastqVariant.FASTQ_SOLEXA, FastqVariant.FASTQ_SOLEXA), "solexa_full_range_as_solexa.fastq");
+        expectedFileNames.put(new FastqVariantPair(FastqVariant.FASTQ_SOLEXA, FastqVariant.FASTQ_ILLUMINA), "solexa_full_range_as_illumina.fastq");
+        expectedFileNames.put(new FastqVariantPair(FastqVariant.FASTQ_ILLUMINA, FastqVariant.FASTQ_SANGER), "illumina_full_range_as_sanger.fastq");
+        expectedFileNames.put(new FastqVariantPair(FastqVariant.FASTQ_ILLUMINA, FastqVariant.FASTQ_SOLEXA), "illumina_full_range_as_solexa.fastq");
+        expectedFileNames.put(new FastqVariantPair(FastqVariant.FASTQ_ILLUMINA, FastqVariant.FASTQ_ILLUMINA), "illumina_full_range_as_illumina.fastq");
+
+        for (FastqVariant variant1 : FastqVariant.values())
+        {
+            FastqReader reader = readers.get(variant1);
+            String inputFileName = inputFileNames.get(variant1);
+            for (FastqVariant variant2 : FastqVariant.values())
+            {
+                FastqWriter writer = writers.get(variant2);
+                String expectedFileName = expectedFileNames.get(new FastqVariantPair(variant1, variant2));
+
+                File tmp = File.createTempFile("convertTest", "fastq");
+                FileWriter fileWriter = new FileWriter(tmp);
+
+                for (Fastq fastq : reader.read(getClass().getResource(inputFileName))) {
+                    writer.append(fileWriter, fastq);
+                }
+
+                try
+                {
+                    fileWriter.close();
+                }
+                catch (Exception e)
+                {
+                    // ignore
+                }
+                
+                FastqReader resultReader = readers.get(variant2);
+                List<Fastq> observed = Lists.newArrayList(resultReader.read(tmp));
+                List<Fastq> expected = Lists.newArrayList(resultReader.read(getClass().getResource(expectedFileName)));
+
+                assertEquals(expected.size(), observed.size());
+                for (int i = 0; i < expected.size(); i++)
+                {
+                    assertEquals(expected.get(i).getDescription(), observed.get(i).getDescription());
+                    assertEquals(expected.get(i).getSequence(), observed.get(i).getSequence());
+                    assertEquals(expected.get(i).getQuality(), observed.get(i).getQuality());
+                    assertEquals(expected.get(i).getVariant(), observed.get(i).getVariant());
+                }
+            }
+        }
+    }
+
+    static final class FastqVariantPair
+    {
+        final FastqVariant variant1;
+        final FastqVariant variant2;
+
+        FastqVariantPair(final FastqVariant variant1, final FastqVariant variant2)
+        {
+            this.variant1 = variant1;
+            this.variant2 = variant2;
+        }
+
+        @Override
+        public int hashCode()
+        {
+            int result = 47;
+            result = 31 * result + variant1.hashCode();
+            result = 31 * result + variant2.hashCode();
+            return result;
+        }
+
+        @Override
+        public boolean equals(final Object o)
+        {
+            if (o == this)
+            {
+                return true;
+            }
+            if (!(o instanceof FastqVariantPair))
+            {
+                return false;
+            }
+            FastqVariantPair pair = (FastqVariantPair) o;
+            return variant1.equals(pair.variant1) && variant2.equals(pair.variant2);
+        }
+    }
+}

--- a/sequencing/src/test/java/org/biojava/bio/program/fastq/FastqToolsTest.java
+++ b/sequencing/src/test/java/org/biojava/bio/program/fastq/FastqToolsTest.java
@@ -338,4 +338,104 @@ public final class FastqToolsTest extends TestCase
             // expected
         }
     }
+
+    public void testConvertNullFastq()
+    {
+        try
+        {
+            FastqTools.convert(null, FastqVariant.FASTQ_SANGER);
+            fail("expected IllegalArgumentException");
+        }
+        catch (IllegalArgumentException e)
+        {
+            // expected
+        }
+    }
+
+    public void testConvertNullVariant()
+    {
+        try
+        {
+            FastqTools.convert(builder.build(), null);
+            fail("expected IllegalArgumentException");
+        }
+        catch (IllegalArgumentException e)
+        {
+            // expected
+        }
+    }
+
+    public void testConvertSameVariant()
+    {
+        Fastq fastq = builder.build();
+        assertEquals(fastq, FastqTools.convert(fastq, fastq.getVariant()));
+    }
+
+    public void testConvertQualitiesNullFastq()
+    {
+        try
+        {
+            FastqTools.convertQualities(null, FastqVariant.FASTQ_SANGER);
+            fail("expected IllegalArgumentException");
+        }
+        catch (IllegalArgumentException e)
+        {
+            // expected
+        }
+    }
+
+    public void testConvertQualitiesNullVariant()
+    {
+        try
+        {
+            FastqTools.convertQualities(builder.build(), null);
+            fail("expected IllegalArgumentException");
+        }
+        catch (IllegalArgumentException e)
+        {
+            // expected
+        }
+    }
+
+    public void testConvertQualitiesSameVariant()
+    {
+        Fastq fastq = builder.build();
+        assertEquals(fastq.getQuality(), FastqTools.convertQualities(fastq, fastq.getVariant()));
+    }
+
+    public void testConvertQualitiesSangerToSolexa()
+    {
+        Fastq fastq = builder.build();
+        assertEquals("yyyy", FastqTools.convertQualities(fastq, FastqVariant.FASTQ_SOLEXA));
+    }
+
+    public void testConvertQualitiesSangerToIllumina()
+    {
+        Fastq fastq = builder.build();
+        assertEquals("yyyy", FastqTools.convertQualities(fastq, FastqVariant.FASTQ_ILLUMINA));
+    }
+
+    public void testConvertQualitiesSolexaToSanger()
+    {
+        Fastq fastq = builder.withVariant(FastqVariant.FASTQ_SOLEXA).build();
+        assertEquals(";;;;", FastqTools.convertQualities(fastq, FastqVariant.FASTQ_SANGER));
+    }
+
+    public void testConvertQualitiesIlluminaToSanger()
+    {
+        Fastq fastq = builder.withVariant(FastqVariant.FASTQ_ILLUMINA).build();
+        assertEquals(";;;;", FastqTools.convertQualities(fastq, FastqVariant.FASTQ_SANGER));
+    }
+
+    public void testConvertQualitiesSolexaToIllumina()
+    {
+        Fastq fastq = builder.withVariant(FastqVariant.FASTQ_SOLEXA).build();
+        assertEquals("ZZZZ", FastqTools.convertQualities(fastq, FastqVariant.FASTQ_ILLUMINA));
+    }
+
+    public void testConvertQualitiesIlluminaToSolexa()
+    {
+        Fastq fastq = builder.withVariant(FastqVariant.FASTQ_ILLUMINA).build();
+        assertEquals("ZZZZ", FastqTools.convertQualities(fastq, FastqVariant.FASTQ_SOLEXA));
+    }
 }

--- a/sequencing/src/test/java/org/biojava/bio/program/fastq/IlluminaFastqWriterTest.java
+++ b/sequencing/src/test/java/org/biojava/bio/program/fastq/IlluminaFastqWriterTest.java
@@ -46,7 +46,7 @@ public final class IlluminaFastqWriterTest
             .build();
     }
 
-    public void testValidateNotIlluminaVariant()
+    public void testConvertIlluminaVariant() throws Exception
     {
         IlluminaFastqWriter writer = new IlluminaFastqWriter();
         Appendable appendable = new StringBuilder();
@@ -56,14 +56,7 @@ public final class IlluminaFastqWriterTest
             .withQuality("quality_")
             .withVariant(FastqVariant.FASTQ_SANGER)
             .build();
-        try
-        {
-            writer.append(appendable, invalid);
-            fail("validate not fastq-illumina variant expected IOException");
-        }
-        catch (IOException e)
-        {
-            // expected
-        }
+
+        writer.append(appendable, invalid);
     }
 }

--- a/sequencing/src/test/java/org/biojava/bio/program/fastq/SangerFastqWriterTest.java
+++ b/sequencing/src/test/java/org/biojava/bio/program/fastq/SangerFastqWriterTest.java
@@ -46,7 +46,7 @@ public final class SangerFastqWriterTest
             .build();
     }
 
-    public void testValidateNotSangerVariant()
+    public void testConvertNotSangerVariant() throws Exception
     {
         SangerFastqWriter writer = new SangerFastqWriter();
         Appendable appendable = new StringBuilder();
@@ -56,14 +56,7 @@ public final class SangerFastqWriterTest
             .withQuality("quality_")
             .withVariant(FastqVariant.FASTQ_SOLEXA)
             .build();
-        try
-        {
-            writer.append(appendable, invalid);
-            fail("validate not fastq-sanger variant expected IOException");
-        }
-        catch (IOException e)
-        {
-            // expected
-        }
+
+        writer.append(appendable, invalid);
     }
 }

--- a/sequencing/src/test/java/org/biojava/bio/program/fastq/SolexaFastqWriterTest.java
+++ b/sequencing/src/test/java/org/biojava/bio/program/fastq/SolexaFastqWriterTest.java
@@ -46,7 +46,7 @@ public final class SolexaFastqWriterTest
             .build();
     }
 
-    public void testValidateNotSolexaVariant()
+    public void testConvertNotSolexaVariant() throws Exception
     {
         SolexaFastqWriter writer = new SolexaFastqWriter();
         Appendable appendable = new StringBuilder();
@@ -56,14 +56,7 @@ public final class SolexaFastqWriterTest
             .withQuality("quality_")
             .withVariant(FastqVariant.FASTQ_ILLUMINA)
             .build();
-        try
-        {
-            writer.append(appendable, invalid);
-            fail("validate not fastq-solexa variant expected IOException");
-        }
-        catch (IOException e)
-        {
-            // expected
-        }
+
+        writer.append(appendable, invalid);
     }
 }


### PR DESCRIPTION
Adds support for explicit conversions, e.g.

```java
// illumina --> sanger variant conversion
FastqReader reader = new IlluminaFastqReader();
FastqWriter writer = new SangerFastqWriter();
FileWriter fileWriter = new FileWriter(new File("sanger.fastq"));

for (Fastq fastq : reader.read(new File("illumina.fastq")))) {
  writer.append(fileWriter, fastq.convertTo(FastqVariant.FASTQ_SANGER));
}
```

Companion pull request to https://github.com/biojava/biojava/pull/334.  As it is not convenient to use both 4.x and 1.x versions of biojava in the same codebase, the code in this package is mostly duplicated, ```org.biojava.bio.program.fastq``` here and ```org.biojava.nbio.sequencing.io.fastq``` in 4.x.